### PR TITLE
Fix AttributeError by adding missing --max_new_tokens argument in eval script 

### DIFF
--- a/llava/eval/model_vqa_mmbench_eta.py
+++ b/llava/eval/model_vqa_mmbench_eta.py
@@ -179,6 +179,7 @@ if __name__ == "__main__":
     parser.add_argument("--lang", type=str, default="en")
     parser.add_argument("--rm_dir", type=str, default='RLHFlow/ArmoRM-Llama3-8B-v0.1')
     parser.add_argument("--clip_dir", type=str, default='openai/clip-vit-large-patch14-336')
+    parser.add_argument("--max_new_tokens", type=int, default=1024) 
 
     parser.add_argument('--pre_threshold', type=float, default=0.16)
     parser.add_argument('--post_threshold', type=float, default=0.06)


### PR DESCRIPTION
Very thanks for your work on this open contribution!
Tested the code in local env and confirmed that the evaluation script now runs correctly after adding the argument.

## Summary
- This PR fixes the following error during ETA-MMBench evaluation:
```AttributeError: 'Namespace' object has no attribute 'max_new_tokens'```

## Changes
- Added `--max_new_tokens` argument to `argparse.ArgumentParser` in `model_vqa_mmbench_eta.py`.
```parser.add_argument("--max_new_tokens", type=int, default=1024)```

## Steps
To check the original error:
```bash
CUDA_VISIBLE_DEVICES=0 bash scripts/eta_mmbench.sh